### PR TITLE
Throwing exception when file is not found.

### DIFF
--- a/source/variantconfig.d
+++ b/source/variantconfig.d
@@ -22,6 +22,10 @@ private:
 			{
 				text = readText(fileName);
 			}
+			else
+			{
+			 	throw new Exception("Specified file was not found.");
+			}
 		}
 		else
 		{


### PR DESCRIPTION
When using this library today, I was surprised when an exception was not thrown when I was testing a scenario where the configuration file was missing.  I may be missing something about your intent.  I created a simple fix for it, which you may wish for me to extend.
